### PR TITLE
Add db.set_operation_mode_json(path) 

### DIFF
--- a/transistordatabase/examples/first_example.py
+++ b/transistordatabase/examples/first_example.py
@@ -56,6 +56,7 @@ def example_update_from_online_database():
     # handle the path to the DatabaseManager(path), to handle a custom database folder to the manager.
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tdb_example_downloaded")
     db = DatabaseManager()
+    db.set_operation_mode_json(path)
     db.update_from_fileexchange(True)
 
     # Compare local database to exchange database:


### PR DESCRIPTION
added a line to the function  'example_update_from_online_database' the  'first_example.py' file. 
it did not work without it. I think it needs it. 