### PR TITLE
add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ transistordatabase/tdb_example_downloaded
 database/
 output/
 .vscode/
+.venv/


### PR DESCRIPTION
some users may use venv. It's better to have this in the .gitignore. 